### PR TITLE
Unit Variable to prevent Overriding of Captive State

### DIFF
--- a/addons/core/functions/fnc_processUnit.sqf
+++ b/addons/core/functions/fnc_processUnit.sqf
@@ -18,6 +18,8 @@
 
 params [["_unit", player, [objNull]]];
 
+if (_unit getVariable [QGVAR(ignore), false]) exitWith {};
+
 if (_unit getVariable [QGVAR(disabled), false]) then {[_unit, 69696969] call FUNC(updateUnit)};
 
 private _helmet = headgear _unit;


### PR DESCRIPTION
As of right now, the only way to "disable" the covert calculation for a specific unit is to set its variable `kjw_imposters_core_disabled`. However, that only guarantees that the unit's score is constantly set to a high value, rendering it overt by setting its captive state to `false`, which messes with other scripts that rely on the captive state of a specific unit.

I added `kjw_imposters_core_ignore` as a unit flag, which causes `addons/core/functions/fnc_processUnit.sqf` to return early. This bypasses `addons/core/functions/fnc_updateUnit.sqf` completely, without overriding captive state one way or another.